### PR TITLE
Rename around existing knife option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ knife backup --help
 Currently the available commands are:
 
 ```bash
-knife backup export [-d DIR]
-knife backup restore [-d DIR]
+knife backup export [-D DIR]
+knife backup restore [-D DIR]
 ```
 
 Note: you should treat this as beta software; I'm using it with success for my needs and hopefully you will find it useful too.

--- a/lib/chef/knife/backup_export.rb
+++ b/lib/chef/knife/backup_export.rb
@@ -30,10 +30,10 @@ module ServerBackup
       require 'chef/cookbook_loader'
     end
 
-    banner "knife backup export [-d DIR]"
+    banner "knife backup export [-D DIR]"
 
     option :backup_dir,
-    :short => "-d DIR",
+    :short => "-D DIR",
     :long => "--backup-directory DIR",
     :description => "Store backup data in DIR.  DIR will be created if it does not already exist.",
     :default => Chef::Config[:knife][:chef_server_backup_dir] ? Chef::Config[:knife][:chef_server_backup_dir] : File.join(".chef", "chef_server_backup")

--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -34,10 +34,10 @@ module ServerBackup
       require 'chef/api_client'
     end
 
-    banner "knife backup restore [-d DIR]"
+    banner "knife backup restore [-D DIR]"
 
     option :backup_dir,
-    :short => "-d DIR",
+    :short => "-D DIR",
     :long => "--backup-directory DIR",
     :description => "Restore backup data from DIR.",
     :default => Chef::Config[:knife][:chef_server_backup_dir] ? Chef::Config[:knife][:chef_server_backup_dir] : File.join(".chef", "chef_server_backup")


### PR DESCRIPTION
Awesome plugin, thanks for putting this together.

Ran into an issue in running

```
knife backup export -d pre_cleanup
```

my results got placed in .chef/chef_server_backup. Looks like the cause is that knife from chef 11.4.0 already specifies a -d option:

```
    -d, --disable-editing            Do not open EDITOR, just accept the data as is
```

pull renames it to -D.
