### PR TITLE
fix superclass mismatch for CookbookUpload

### DIFF
--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -17,7 +17,7 @@
 
 class Chef
   class Knife
-    class CookbookUpload
+    class CookbookUpload < Knife
       def check_for_dependencies!(cookbook)
       end
     end


### PR DESCRIPTION
...you get " superclass mismatch for class CookbookUpload (TypeError)" depending on load order
