### PR TITLE
Added a default task to the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,3 @@
 require "bundler/gem_tasks"
+
+task :default => :build


### PR DESCRIPTION
Added a default task to the Rakefile so that all you have to do is type 'rake' to build knife-backup.
