### PR TITLE
Rescue backup-standard if load fails

### DIFF
--- a/lib/chef/knife/backup_export.rb
+++ b/lib/chef/knife/backup_export.rb
@@ -99,11 +99,18 @@ module ServerBackup
       klass.list.each do |component_name, url|
         next if component == "environments" && component_name == "_default"
         ui.msg "Backing up #{component} #{component_name}"
-        component_obj = klass.load(component_name)
-        File.open(File.join(dir, "#{component_name}.json"), "w") do |component_file|
-          #component_file.print(component_obj.to_json)
-          component_file.print(JSON.pretty_generate(component_obj))
+        begin
+          component_obj = klass.load(component_name)
+        rescue
+          ui.msg "Failed to load #{component} #{component_name}... Skipping"
+        else
+          File.open(File.join(dir, "#{component_name}.json"), "w") do |component_file|
+            #component_file.print(component_obj.to_json)
+            component_file.print(JSON.pretty_generate(component_obj))
+          end
         end
+
+
       end
     end
 


### PR DESCRIPTION
If a node's client is deleted between when when knife-backup gets the client list and when it attempts to load it then the entire backup process is stopped.  This fixes it using the same strategy that is used when a failed cookbook download occurs.
