### PR TITLE
Restore clients 'validator' property.

### DIFF
--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -122,7 +122,8 @@ module ServerBackup
           rest.post_rest("clients", {
             :name => client['name'],
             :public_key => client['public_key'],
-            :admin => client['admin']
+            :admin => client['admin'],
+            :validator => client['validator']
           })
         rescue Net::HTTPServerException => e
           handle_error 'client', client['name'], e


### PR DESCRIPTION
When restoring the `chef-validator` client from backup, the `validator` property gets lost and must be manually recreated. This patch pulls the `validator` property from the client's json and uses it on client creation.
