### PR TITLE
Add option to backup cookbooks without version tag

### DIFF
--- a/lib/chef/knife/backup_export.rb
+++ b/lib/chef/knife/backup_export.rb
@@ -46,6 +46,12 @@ module ServerBackup
       :description => "The version of the cookbook to download",
       :boolean => true
 
+    option :cbnover,
+      :short => "-Q",
+      :long => "--cookbook-noversion",
+      :description => "Don't tag cookbooks with version",
+      :boolean => true
+
     def run
       validate!
       components = name_args.empty? ? COMPONENTS : name_args
@@ -136,7 +142,7 @@ module ServerBackup
       ui.msg "Backing up cookbooks"
       dir = File.join(config[:backup_dir], "cookbooks")
       FileUtils.mkdir_p(dir)
-      if config[:latest]
+      if config[:latest] or config[:cbnover]
         cookbooks = rest.get_rest("/cookbooks?latest")
       else
         cookbooks = rest.get_rest("/cookbooks?num_versions=all")
@@ -150,6 +156,12 @@ module ServerBackup
           dld.config[:force] = true
           begin
             dld.run
+            if config[:cbnover]
+              cbpath_withver = File.join(dir, cb + "-" + ver['version'])
+              cbpath_nover = File.join(dir, cb)
+              ui.msg "Renaming cookbook to #{cbpath_nover}"
+              FileUtils.mv(cbpath_withver, cbpath_nover)
+            end
           rescue
             ui.msg "Failed to download cookbook #{cb} version #{ver['version']}... Skipping"
             FileUtils.rm_r(File.join(dir, cb + "-" + ver['version']))

--- a/lib/chef/knife/backup_export.rb
+++ b/lib/chef/knife/backup_export.rb
@@ -160,6 +160,9 @@ module ServerBackup
               cbpath_withver = File.join(dir, cb + "-" + ver['version'])
               cbpath_nover = File.join(dir, cb)
               ui.msg "Renaming cookbook to #{cbpath_nover}"
+              if File.directory?(cbpath_nover)
+                FileUtils.rm_r(cbpath_nover)
+              end
               FileUtils.mv(cbpath_withver, cbpath_nover)
             end
           rescue

--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -122,7 +122,8 @@ module ServerBackup
           rest.post_rest("clients", {
             :name => client['name'],
             :public_key => client['public_key'],
-            :admin => client['admin']
+            :admin => client['admin'],
+            :validator => client['validator']
           })
         rescue Net::HTTPServerException => e
           handle_error 'client', client['name'], e

--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -163,7 +163,12 @@ module ServerBackup
         next unless File.directory?(cb)
         full_cb = File.expand_path(cb)
         cb_name = File.basename(cb)
-        cookbook = cb_name.reverse.split('-',2).last.reverse
+        #cookbook = cb_name.reverse.split('-',2).last.reverse
+        if m = cb_name.match(/^(.*)-\d+\.\d+(\.\d+)?$/)
+          cookbook = m[1]
+        else
+          cookbook = cb_name
+        end
         full_path = File.join(File.dirname(full_cb), cookbook)
 
         begin

--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -160,13 +160,14 @@ module ServerBackup
       ui.info "=== Restoring cookbooks ==="
       cookbooks = Dir.glob(File.join(config[:backup_dir], "cookbooks", '*'))
       cookbooks.each do |cb|
+        next unless File.directory?(cb)
         full_cb = File.expand_path(cb)
         cb_name = File.basename(cb)
         cookbook = cb_name.reverse.split('-',2).last.reverse
         full_path = File.join(File.dirname(full_cb), cookbook)
 
         begin
-          File.symlink(full_cb, full_path)
+          File.symlink(full_cb, full_path) if full_cb != full_path
           cbu = Chef::Knife::CookbookUpload.new
           Chef::Knife::CookbookUpload.load_deps
           cbu.name_args = [ cookbook ]
@@ -176,7 +177,7 @@ module ServerBackup
         rescue Net::HTTPServerException => e
           handle_error 'cookbook', cb_name, e
         ensure
-          File.unlink(full_path)
+          File.unlink(full_path) if File.symlink?(full_path)
         end
       end
     end


### PR DESCRIPTION
In my use case for knife-backup, I may want to only keep and restore the latest version of a cookbook. This branch allows restoring cookbooks whether or not they have a version tag in their base directory name, and adds an option to remove the version tag from cookbook names on export.