### PR TITLE
add json dep

### DIFF
--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -33,6 +33,7 @@ module ServerBackup
       require 'chef/cookbook_uploader'
       require 'chef/api_client'
       require 'securerandom'
+      require 'json'
     end
 
     banner "knife backup restore [COMPONENT [COMPONENT ...]] [-D DIR] (options)"


### PR DESCRIPTION
knife from chef client versions > 11.12 dies on 'knife backup restore {clients|users}' with the error "Exception: NoMethodError: undefined method `create_id=' for JSON:Module"

chef/json_compat.rb dropped its stdlib dep after 11.12, and its native JSONCompat library doesn't have the create_id method. In chef-client > 11.12, you can drop the create_id and use load() instead of parse(), but that doesn't work in older versions.  "require 'json'" seems to be the simplest fix compatible with older and newer clients.
