### PR TITLE
Update usage section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ gem install knife-backup
 
 ## Usage
 
-For a list of commands:
-
-```bash
-knife backup --help
-```
-
 Currently the available commands are:
 
 ```bash
@@ -41,6 +35,12 @@ knife backup restore [component component ...] [-D DIR]
 
 #Example:
 knife backup export cookbooks roles environments -D ~/my_chef_backup
+```
+
+For more information on commands:
+
+```bash
+knife backup SUB-COMMAND --help
 ```
 
 Note: you should treat this as beta software; I'm using it with success for my needs and hopefully you will find it useful too.


### PR DESCRIPTION
For reference, here's the usage text from `knife backup --help`:

```bash
$ knife backup --help
FATAL: Cannot find sub command for: 'backup --help'
Available backup subcommands: (for details, knife SUB-COMMAND --help)

** BACKUP COMMANDS **
knife backup export [COMPONENT [COMPONENT ...]] [-D DIR] (options)
knife backup restore [COMPONENT [COMPONENT ...]] [-D DIR] (options)
```

This definitely gives a list of subcommands, but I think the `FATAL` error is unsettling. 