### PR TITLE
Fixed restore confirmation typo

### DIFF
--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -47,7 +47,7 @@ module ServerBackup
     def run
       ui.warn "This will overwrite existing data!"
       ui.warn "Backup is at least 1 day old" if (Time.now - File.atime(config[:backup_dir])) > 86400
-      ui.confirm "Do you want to restore backup, possibly overwriting exisitng data"
+      ui.confirm "Do you want to restore backup, possibly overwriting existing data"
       validate!
       components = name_args.empty? ? COMPONENTS : name_args
       Array(components).each { |component| self.send(component) }


### PR DESCRIPTION
It's a minor thing, but I was using this today and noticed the typo so I fixed it.