### PR TITLE
This patch allow chef 12 to import all versions of a cookbook.

### DIFF
--- a/lib/chef/knife/backup_restore.rb
+++ b/lib/chef/knife/backup_restore.rb
@@ -160,12 +160,14 @@ module ServerBackup
     def cookbooks
       ui.info "=== Restoring cookbooks ==="
       cookbooks = Dir.glob(File.join(config[:backup_dir], "cookbooks", '*'))
-      cookbooks.each do |cb|
+      #Make tmp dir
+       cookbooks.each do |cb|
+        FileUtils.rm_rf(config[:backup_dir] + "/tmp")
+        Dir.mkdir config[:backup_dir] + "/tmp"
         full_cb = File.expand_path(cb)
         cb_name = File.basename(cb)
         cookbook = cb_name.reverse.split('-',2).last.reverse
-        full_path = File.join(File.dirname(full_cb), cookbook)
-
+        full_path = File.join(File.dirname(config[:backup_dir] + "/tmp"), cookbook) 
         begin
           File.symlink(full_cb, full_path)
           cbu = Chef::Knife::CookbookUpload.new
@@ -173,12 +175,15 @@ module ServerBackup
           cbu.name_args = [ cookbook ]
           cbu.config[:cookbook_path] = File.dirname(full_path)
           ui.info "Restoring cookbook #{cbu.name_args}"
+          ui.info "TMP=" + config[:backup_dir] + "/tmp"
           cbu.run
         rescue Net::HTTPServerException => e
           handle_error 'cookbook', cb_name, e
         ensure
           File.unlink(full_path)
         end
+        ui.info "Deleting TMP"
+        FileUtils.rm_rf(config[:backup_dir] + "/tmp")
       end
     end
 


### PR DESCRIPTION
There are chef pathing issues if the dirctory with the -D option is
used. This patch creates a temp directory, and lets the symlinking occur
there. This keeps extranious cookbooks out of the chef path and allows
all exported versions to be imported without issue.