### PR TITLE
Export data as expected by import method

### DIFF
--- a/lib/chef/knife/backup_export.rb
+++ b/lib/chef/knife/backup_export.rb
@@ -72,7 +72,22 @@ module ServerBackup
     end
 
     def nodes
-      backup_standard("nodes", Chef::Node)
+      component = "nodes"
+      ui.msg "Backing up #{component}"
+      dir = File.join(config[:backup_dir], component)
+      FileUtils.mkdir_p(dir)
+      Chef::Node.list.each do |component_name, url|
+        next if component == "environments" && component_name == "_default"
+        ui.msg "Backing up #{component} #{component_name}"
+        component_obj = Chef::Node.load(component_name).for_json
+        unless component_obj
+          ui.error "Could not load #{klass} #{component_name}."
+          next
+        end
+        File.open(File.join(dir, "#{component_name}.json"), "w") do |component_file|
+          component_file.print(JSON.pretty_generate(component_obj))
+        end
+      end
     end
 
     def clients


### PR DESCRIPTION
The original code was using `to_hash` in `backup_standard`. However, `to_hash` (http://www.rubydoc.info/gems/chef/Chef/Node#to_hash-instance_method) doesn't export the data expected from the `from_hash` method on `Node` (eventually called from http://www.rubydoc.info/gems/chef/Chef%2FKnife%2FCore%2FObjectLoader%3Aobject_from_file).

Using `for_json`(http://www.rubydoc.info/gems/chef/Chef%2FNode%3Afor_json) exports the attributes individually in the json, and is allowing me to load the nodes correctly from the backup.

addresses #57 
